### PR TITLE
Fix remote port always returned 0

### DIFF
--- a/contrib/ctxWinsock.ctl
+++ b/contrib/ctxWinsock.ctl
@@ -213,7 +213,9 @@ Property Let RemoteHost(sValue As String)
 End Property
 
 Property Get RemotePort() As Long
-    If Not m_oSocket Is Nothing Then
+    If Not m_oRequestSocket Is Nothing Then
+        m_oRequestSocket.GetPeerName vbNullString, RemotePort
+    ElseIf Not m_oSocket Is Nothing Then
         m_oSocket.GetPeerName vbNullString, RemotePort
     Else
         RemotePort = m_lRemotePort


### PR DESCRIPTION
I took this part from pvSocket() algorithm, otherwise port is always reported zero in the event.