### PR TITLE
Get rid of IUnknown, this allows us to drop stdole reference

### DIFF
--- a/contrib/cHttpDownload.cls
+++ b/contrib/cHttpDownload.cls
@@ -49,7 +49,7 @@ Private Const STGM_CREATE                   As Long = &H1000
 
 Private Declare Sub CopyMemory Lib "kernel32" Alias "RtlMoveMemory" (Destination As Any, Source As Any, ByVal Length As Long)
 Private Declare Function vbaObjSetAddref Lib "msvbvm60" Alias "__vbaObjSetAddref" (oDest As Any, ByVal lSrcPtr As Long) As Long
-Private Declare Function SHCreateStreamOnFile Lib "shlwapi" Alias "SHCreateStreamOnFileW" (ByVal pszFile As Long, ByVal grfMode As Long, ppstm As IUnknown) As Long
+Private Declare Function SHCreateStreamOnFile Lib "shlwapi" Alias "SHCreateStreamOnFileW" (ByVal pszFile As Long, ByVal grfMode As Long, ppstm As Object) As Long
 Private Declare Function DispCallFunc Lib "oleaut32" (ByVal pvInstance As Long, ByVal oVft As Long, ByVal lCc As Long, ByVal vtReturn As VbVarType, ByVal cActuals As Long, prgVt As Any, prgpVarg As Any, pvargResult As Variant) As Long
 
 '=========================================================================
@@ -75,7 +75,7 @@ Attribute m_oSocket.VB_VarHelpID = -1
 Private m_uRemote               As UcsParsedUrl
 Private m_sLocalFileName        As String
 Private m_lStreamFlags          As Long
-Private m_pFileStream           As IUnknown
+Private m_pFileStream           As Object
 Private m_dStartDate            As Date
 Private m_lCallbackPtr          As Long
 Private m_eState                As UcsStateEnum
@@ -523,19 +523,19 @@ Private Function pvIsProtocolSecure(sProtocol As String) As Boolean
     pvIsProtocolSecure = (LCase$(sProtocol) = "https")
 End Function
 
-Private Function IStream_Read(pStm As IUnknown, baBuffer() As Byte, Optional BytesRead As Long) As Long
+Private Function IStream_Read(pStm As Object, baBuffer() As Byte, Optional BytesRead As Long) As Long
     If Not pStm Is Nothing And UBound(baBuffer) >= 0 Then
         IStream_Read = DispCallByVtbl(pStm, 3, VarPtr(baBuffer(0)), UBound(baBuffer) + 1, VarPtr(BytesRead))
     End If
 End Function
 
-Private Function IStream_Write(pStm As IUnknown, baBuffer() As Byte, Optional BytesWritten As Long) As Long
+Private Function IStream_Write(pStm As Object, baBuffer() As Byte, Optional BytesWritten As Long) As Long
     If Not pStm Is Nothing And UBound(baBuffer) >= 0 Then
         IStream_Write = DispCallByVtbl(pStm, 4, VarPtr(baBuffer(0)), UBound(baBuffer) + 1, VarPtr(BytesWritten))
     End If
 End Function
 
-Private Function DispCallByVtbl(pUnk As IUnknown, ByVal lIndex As Long, ParamArray A() As Variant) As Variant
+Private Function DispCallByVtbl(pUnk As Object, ByVal lIndex As Long, ParamArray A() As Variant) As Variant
     Const CC_STDCALL    As Long = 4
     Dim lIdx            As Long
     Dim vParam()        As Variant

--- a/contrib/cHttpRequest.cls
+++ b/contrib/cHttpRequest.cls
@@ -125,7 +125,7 @@ Private Declare Function lstrlenW Lib "kernel32" (ByVal lpString As Long) As Lon
 Private Declare Function DispCallFunc Lib "oleaut32" (ByVal pvInstance As Long, ByVal oVft As Long, ByVal lCc As Long, ByVal vtReturn As VbVarType, ByVal cActuals As Long, prgVt As Any, prgpVarg As Any, pvargResult As Variant) As Long
 Private Declare Function WinHttpGetDefaultProxyConfiguration Lib "winhttp" (pProxyInfo As Any) As Long
 '--- shlwapi
-Private Declare Function SHCreateMemStream Lib "shlwapi" Alias "#12" (pInit As Any, ByVal cbInit As Long) As stdole.IUnknown
+Private Declare Function SHCreateMemStream Lib "shlwapi" Alias "#12" (pInit As Any, ByVal cbInit As Long) As Object
 Private Declare Function UrlEscape Lib "shlwapi" Alias "UrlEscapeW" (ByVal pszURL As Long, ByVal pszEscaped As Long, pcchEscaped As Long, ByVal dwFlags As Long) As Long
 '--- libarchive
 Private Declare Function archive_read_new Lib "archiveint" Alias "_archive_read_new@0" () As Long
@@ -229,7 +229,7 @@ Private Type UcsRequestType
     Async               As Boolean
     Headers             As Object
     NumOfRedirects      As Long
-    SendStream          As IUnknown
+    SendStream          As Object
     SendBuffer          As UcsBuffer
 End Type
 
@@ -238,7 +238,7 @@ Private Type UcsResponseType
     StatusText          As String
     AllHeaders          As String
     Headers             As Object
-    RecvStream          As IUnknown
+    RecvStream          As Object
     Text                As String
     BytesProgress       As Double
     ContentLength       As Double
@@ -1032,7 +1032,7 @@ Private Function pvRecvBody(baData() As Byte, uResponse As UcsResponseType, Opti
     Dim lSize           As Long
     Dim lIdx            As Long
     Dim uChunk          As UcsBuffer
-    Dim pOutput         As IUnknown
+    Dim pOutput         As Object
     
     On Error GoTo EH
     With uResponse
@@ -1584,7 +1584,7 @@ Private Function pvMapCharset(sCharset As String) As UcsAsyncSocketCodePageEnum
     End Select
 End Function
 
-Private Function pvUngzipStream(pInput As IUnknown, pOutput As IUnknown) As Boolean
+Private Function pvUngzipStream(pInput As Object, pOutput As Object) As Boolean
     Const FUNC_NAME     As String = "pvUngzipStream"
     Const BUFF_SIZE     As Long = 65536
     Dim baData()        As Byte
@@ -1663,7 +1663,7 @@ EH:
     PrintError FUNC_NAME
 End Function
 
-Public Function ArchiveReaderCallback(ByVal hArchive As Long, ByVal pInput As IUnknown, lBufferPtr As Long) As Long
+Public Function ArchiveReaderCallback(ByVal hArchive As Long, ByVal pInput As Object, lBufferPtr As Long) As Long
 Attribute ArchiveReaderCallback.VB_MemberFlags = "40"
     Const FUNC_NAME     As String = "ArchiveReaderCallback"
     Dim hResult         As Long
@@ -1806,7 +1806,7 @@ End Function
 
 '= buffers ===============================================================
 
-Private Function AsIStream(ByVal pUnk As IUnknown) As IUnknown
+Private Function AsIStream(ByVal pUnk As Object) As Object
     Const IDX_QueryInterface As Long = 0
     Static IID_IStream(0 To 3) As Long
     Dim hResult         As Long
@@ -1823,19 +1823,19 @@ Private Function AsIStream(ByVal pUnk As IUnknown) As IUnknown
     End If
 End Function
 
-Private Function IStream_Read(pStm As IUnknown, baData() As Byte, Optional BytesRead As Long) As Long
+Private Function IStream_Read(pStm As Object, baData() As Byte, Optional BytesRead As Long) As Long
     If Not pStm Is Nothing And UBound(baData) >= 0 Then
         IStream_Read = DispCallByVtbl(pStm, 3, VarPtr(baData(0)), UBound(baData) + 1, VarPtr(BytesRead))
     End If
 End Function
 
-Private Function IStream_Write(pStm As IUnknown, baData() As Byte, Optional BytesWritten As Long) As Long
+Private Function IStream_Write(pStm As Object, baData() As Byte, Optional BytesWritten As Long) As Long
     If Not pStm Is Nothing And UBound(baData) >= 0 Then
         IStream_Write = DispCallByVtbl(pStm, 4, VarPtr(baData(0)), UBound(baData) + 1, VarPtr(BytesWritten))
     End If
 End Function
 
-Private Function IStream_Seek(pStm As stdole.IUnknown, ByVal cMove As Currency, ByVal dwOrigin As Long, Optional NewPosition As Currency) As Long
+Private Function IStream_Seek(pStm As Object, ByVal cMove As Currency, ByVal dwOrigin As Long, Optional NewPosition As Currency) As Long
     If Not pStm Is Nothing Then
         IStream_Seek = DispCallByVtbl(pStm, 5, cMove, dwOrigin, VarPtr(NewPosition))
     Else
@@ -1843,7 +1843,7 @@ Private Function IStream_Seek(pStm As stdole.IUnknown, ByVal cMove As Currency, 
     End If
 End Function
 
-Private Function IStream_GetSize(pStream As IUnknown) As Double
+Private Function IStream_GetSize(pStream As Object) As Double
     Dim hResult         As Long
     Dim cPos            As Currency
     
@@ -1860,7 +1860,7 @@ Private Function IStream_GetSize(pStream As IUnknown) As Double
     IStream_GetSize = CDbl(cPos) * 10000#
 End Function
 
-Private Function DispCallByVtbl(pUnk As IUnknown, ByVal lIndex As Long, ParamArray A() As Variant) As Variant
+Private Function DispCallByVtbl(pUnk As Object, ByVal lIndex As Long, ParamArray A() As Variant) As Variant
     Const CC_STDCALL    As Long = 4
     Dim lIdx            As Long
     Dim vParam()        As Variant

--- a/contrib/cRateLimiter.cls
+++ b/contrib/cRateLimiter.cls
@@ -62,7 +62,7 @@ Private m_dblLimit              As Long
 Private m_cEvents               As Collection
 Private m_dblCurSize            As Long
 Private m_dblStartTime          As Double
-Private m_pTimer                As IUnknown
+Private m_pTimer                As Object
 Private m_bInSet                As Boolean
 
 '=========================================================================
@@ -160,7 +160,7 @@ Private Function InitAddressOfMethod(pObj As Object, ByVal MethodParamCount As L
     Debug.Assert lSize = THUNK_SIZE
 End Function
 
-Private Function InitFireOnceTimerThunk(pObj As Object, ByVal pfnCallback As Long, Optional Delay As Long) As IUnknown
+Private Function InitFireOnceTimerThunk(pObj As Object, ByVal pfnCallback As Long, Optional Delay As Long) As Object
     Const STR_THUNK     As String = "6AAAAABag+oFgeogERkAV1aLdCQUg8YIgz4AdCqL+oHHBBMZAIvCBSgSGQCri8IFZBIZAKuLwgV0EhkAqzPAq7kIAAAA86WBwgQTGQBSahj/UhBai/iLwqu4AQAAAKszwKuri3QkFKWlg+8Yi0IMSCX/AAAAUItKDDsMJHULWIsPV/9RFDP/62P/QgyBYgz/AAAAjQTKjQTIjUyIMIB5EwB101jHAf80JLiJeQTHQQiJRCQEi8ItBBMZAAWgEhkAUMHgCAW4AAAAiUEMWMHoGAUA/+CQiUEQiU8MUf90JBRqAGoAiw//URiJRwiLRCQYiTheX7g0ExkALSARGQAFABQAAMIQAGaQi0QkCIM4AHUqg3gEAHUkgXgIwAAAAHUbgXgMAAAARnUSi1QkBP9CBItEJAyJEDPAwgwAuAJAAIDCDACQi1QkBP9CBItCBMIEAA8fAItUJAT/SgSLQgR1HYtCDMZAEwCLCv9yCGoA/1Eci1QkBIsKUv9RFDPAwgQAi1QkBIsKi0EohcB0J1L/0FqD+AF3SYsKUv9RLFqFwHU+iwpSavD/cSD/USRaqQAAAAh1K4sKUv9yCGoA/1EcWv9CBDPAUFT/chD/UhSLVCQIx0IIAAAAAFLodv///1jCFABmkA==" ' 27.3.2019 9:14:57
     Const THUNK_SIZE    As Long = 5652
     Static hThunk       As Long

--- a/src/cAsyncSocket.cls
+++ b/src/cAsyncSocket.cls
@@ -335,7 +335,7 @@ Private Const DEF_TIMEOUT           As Long = 5000
 Private Const MAX_SOCKETS           As Long = &HC000& - WM_SOCKET_NOTIFY
 
 Private m_hSocket               As Long
-Private m_pCleanup              As IUnknown
+Private m_pCleanup              As Object
 Private m_oHelperWindow         As cAsyncSocket
 Private m_lIndex                As Long
 Private m_lLastError            As Long
@@ -355,8 +355,8 @@ End Type
 
 Private Type UcsHelperWindowStateType
     hWnd                As Long
-    Notify              As IUnknown
-    Cleanup             As IUnknown
+    Notify              As Object
+    Cleanup             As Object
     SocketPtr()         As Long
     Pos                 As Long
     Count               As Long
@@ -1922,7 +1922,7 @@ Private Function InitAddressOfMethod(pObj As Object, ByVal MethodParamCount As L
     Debug.Assert lSize = THUNK_SIZE
 End Function
 
-Private Function InitAsyncSelectNotifyThunk(ByVal hWnd As Long, pObj As Object, ByVal pfnCallback As Long) As IUnknown
+Private Function InitAsyncSelectNotifyThunk(ByVal hWnd As Long, pObj As Object, ByVal pfnCallback As Long) As Object
     Dim STR_THUNK       As String: STR_THUNK = "6AAAAABageplEEQAV1aLdCQUg8YIgz4AdDeL+oHHBBNEAIvCBQgRRACri8IFRBFEAKuLwgVUEUQAq4vCBYARRACri8IFgBJEAKu5CQAAAPOlgcIEE0QAi/qDxziLwqu4AQAAAKszwKuLRCQMqzPAq4t0JBSlpTPAq6urq4PvLGoAV/9yDP93DP9SFItEJBiJOF5fuGgTRAAtYBBEAAUAMAAAwhAADx8Ai0QkCIM4AHUqg3gEAHUkgXgIwAAAAHUbgXgMAAAARnUSi1QkBP9CBItEJAyJEDPAwgwAuAJAAIDCDACQi1QkBP9CBItCBMIEAA8fAItUJAT/SgSLQgR1GlKLClL/cQz/cgz/URhaiwr/chBqAP9RJDPAwgQADx8AVYvsi1UY/0IE/0IoUosK/3UU/3UQ/3UM/3UI/1EcWlCLQiBAJf8DAAA7Qhx0GlBWV416LItCII08x408h411DKWlpV9ej0Igi0IkhcAPhZ4AAACLQhCFwA+FkwAAAIsKi0EwhcB0MFL/0FqJQgiD+AF3a4sKi0E0hcB0CFL/0FqFwHVaiwpSavD/cSj/USxaqQAAAAh1R4tCKDtCBHRSi0IUhcB0S8dCJAEAAAD/ciBSM8BQVP9yIP9yHGgABAAAjUIsUP9yFP9SGFhax0IkAAAAAFiJQhw7QiB0Feu5UosK/3EQagBqAGoA/1EgWolCEP9KKFLo2v7//1hdwhgAkOgAAAAAWoHqhRJEAIHCPBNEAP9CBP9CKIsKi0EwhcB0DFL/0FqJQgiD+AF3SlKLCv9yEGoA/1EkWotCKDtCBHQvi0IUhcB0KP9yIFIzwFBU/3Ig/3IcaAAEAACNQixQ/3IU/1IYWFpYiUIcO0IgdcnHQhAAAAAA/0ooUuhU/v//whAAkI1EQAGNREAB" ' 27.6.2020 20:49:42
     Const THUNK_SIZE    As Long = 13064
     Static hThunk       As Long
@@ -1955,7 +1955,7 @@ Private Function InitAsyncSelectNotifyThunk(ByVal hWnd As Long, pObj As Object, 
     Debug.Assert lSize = THUNK_SIZE
 End Function
 
-Private Function InitCleanupThunk(ByVal hHandle As Long, sModuleName As String, sProcName As String) As IUnknown
+Private Function InitCleanupThunk(ByVal hHandle As Long, sModuleName As String, sProcName As String) As Object
     Const STR_THUNK     As String = "6AAAAABag+oFgepQEDwBV1aLdCQUgz4AdCeL+oHHPBE8AYvCBcwQPAGri8IFCBE8AauLwgUYETwBq7kCAAAA86WBwjwRPAFSahD/Ugxai/iLwqu4AQAAAKuLRCQMq4tEJBCrg+8Qi0QkGIk4Xl+4UBE8AS1QEDwBwhAAkItEJAiDOAB1KoN4BAB1JIF4CMAAAAB1G4F4DAAAAEZ1EotUJAT/QgSLRCQMiRAzwMIMALgCQACAwgwAkItUJAT/QgSLQgTCBAAPHwCLVCQE/0oEi0IEdRL/cgj/UgyLVCQEiwpS/1EQM8DCBAAPHwA=" ' 25.3.2019 14:03:56
     Const THUNK_SIZE    As Long = 256
     Static hThunk       As Long
@@ -1979,7 +1979,7 @@ Private Function InitCleanupThunk(ByVal hHandle As Long, sModuleName As String, 
     End If
 End Function
 
-Private Property Get ThunkPrivateData(pThunk As IUnknown, Optional ByVal Index As Long) As Long
+Private Property Get ThunkPrivateData(pThunk As Object, Optional ByVal Index As Long) As Long
     Dim lPtr            As Long
     
     lPtr = ObjPtr(pThunk)
@@ -1989,7 +1989,7 @@ Private Property Get ThunkPrivateData(pThunk As IUnknown, Optional ByVal Index A
     End If
 End Property
 
-Private Property Let ThunkPrivateData(pThunk As IUnknown, Optional ByVal Index As Long, ByVal lValue As Long)
+Private Property Let ThunkPrivateData(pThunk As Object, Optional ByVal Index As Long, ByVal lValue As Long)
     Dim lPtr            As Long
     
     lPtr = ObjPtr(pThunk)


### PR DESCRIPTION
I am not sure what the consequences of this might be, but this allows me to drop the stdole dependency, which was causing me a headache trying to keep the `.vbp` file unchanging across machines.

It still compiles (I am using the "native" driver module), and still works fine for both the async control (with TLS) as well as the HTTP(S) request implementation.

If this is an incredibly stupid idea, do let me know as well :)