### PR TITLE
Fix setting CompareMode in pvParseHeaderAttribs

### DIFF
--- a/contrib/cHttpRequest.cls
+++ b/contrib/cHttpRequest.cls
@@ -1496,7 +1496,7 @@ Private Function pvParseHeaderAttribs(ByVal sHeader As String) As Object
     
     '--- TODO: need regex parser for semi-colons in quoted values
     Set pvParseHeaderAttribs = CreateObject("Scripting.Dictionary")
-    m_uRequest.Headers.CompareMode = vbTextCompare
+    pvParseHeaderAttribs.CompareMode = vbTextCompare
     vSplit = Split(sHeader, ";")
     If UBound(vSplit) > 0 Then
         For Each vElem In vSplit


### PR DESCRIPTION
This somehow "just works" in Windows, but I doubt correctly.
Noticed this was an issue because it causes an actual error in Wine (which I don't think is expected, but it was helpful here).
This just seems to be a bug? If there's a reason to set the `CompareMode` on `m_uRequest.Headers`, feel free to close the PR, but I think this is the intention as `CompareMode` is already set on the other dictionary